### PR TITLE
feat: Add custom serialization and deserialization hash classes.

### DIFF
--- a/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/FixedBytes.java
+++ b/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/FixedBytes.java
@@ -4,6 +4,13 @@ import java.util.Arrays;
 
 abstract public class FixedBytes extends ByteData {
 
+    /**
+     * Needed for serialization/deserialization.
+     */
+    public FixedBytes() {
+        super(new byte[0]);
+    }
+
     protected FixedBytes(byte[] value, int expectedSize) {
         super(value);
         if (value.length != expectedSize) {
@@ -34,7 +41,7 @@ abstract public class FixedBytes extends ByteData {
         }
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
-            data[i / 2] = Integer.valueOf(hex.substring(i, i+2), 16).byteValue();
+            data[i / 2] = Integer.valueOf(hex.substring(i, i + 2), 16).byteValue();
         }
         return data;
     }

--- a/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Hash256.java
+++ b/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Hash256.java
@@ -1,9 +1,14 @@
 package io.emeraldpay.polkaj.types;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
 /**
  * A 256 bit value, commonly used as a hash
  */
-public class Hash256 extends FixedBytes implements Comparable<Hash256> {
+public class Hash256 extends FixedBytes implements Comparable<Hash256>, Serializable {
 
     /**
      * Length in bytes (32 byte)
@@ -14,7 +19,7 @@ public class Hash256 extends FixedBytes implements Comparable<Hash256> {
      * Create a new value. Makes sure the input is correct, if not throws an exception
      *
      * @param value 32 byte value
-     * @throws NullPointerException if value is null
+     * @throws NullPointerException     if value is null
      * @throws IllegalArgumentException is size is not 32 bytes
      */
     public Hash256(byte[] value) {
@@ -36,7 +41,7 @@ public class Hash256 extends FixedBytes implements Comparable<Hash256> {
      * @param hex hex value, may optionally start with 0x prefix
      * @return hash instance
      * @throws IllegalArgumentException if value has invalid length
-     * @throws NumberFormatException if value has invalid format (non-hex characters, etc)
+     * @throws NumberFormatException    if value has invalid format (non-hex characters, etc)
      */
     public static Hash256 from(String hex) {
         byte[] parsed = parseHex(hex, SIZE_BYTES);
@@ -46,5 +51,39 @@ public class Hash256 extends FixedBytes implements Comparable<Hash256> {
     @Override
     public int compareTo(Hash256 o) {
         return super.compareTo(o);
+    }
+
+    /**
+     * Custom serialization logic. Writes the length and value of the underlying byte array for the hash.
+     *
+     * @param out the {@link ObjectOutputStream} to write this object to
+     * @throws IOException if an I/O error occurs while writing to the stream
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
+    /**
+     * Custom deserialization logic. Validates the required length and sets the underlying byte array using reflection.
+     *
+     * @param in the {@link ObjectInputStream} to read this object from
+     * @throws IOException            if the length of the serialized data is invalid or if an I/O error occurs
+     * @throws ClassNotFoundException if the class of a serialized object cannot be found
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        int length = in.readInt();
+        if (length != SIZE_BYTES) {
+            throw new IOException("Invalid Hash256 length: " + length);
+        }
+        byte[] value = new byte[length];
+        in.readFully(value);
+        try {
+            java.lang.reflect.Field valueField = ByteData.class.getDeclaredField("value");
+            valueField.setAccessible(true);
+            valueField.set(this, value.clone());
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new IOException("Failed to initialize Hash256", e);
+        }
     }
 }

--- a/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Hash512.java
+++ b/polkaj-common-types/src/main/java/io/emeraldpay/polkaj/types/Hash512.java
@@ -1,9 +1,14 @@
 package io.emeraldpay.polkaj.types;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
 /**
  * A 512 bit value, commonly used as a hash
  */
-public class Hash512 extends FixedBytes implements Comparable<Hash512> {
+public class Hash512 extends FixedBytes implements Comparable<Hash512>, Serializable {
 
     /**
      * Length in bytes (64 byte)
@@ -14,7 +19,7 @@ public class Hash512 extends FixedBytes implements Comparable<Hash512> {
      * Create a new value. Makes sure the input is correct, if not throws an exception
      *
      * @param value 64 byte value
-     * @throws NullPointerException if value is null
+     * @throws NullPointerException     if value is null
      * @throws IllegalArgumentException is size is not 64 bytes
      */
     public Hash512(byte[] value) {
@@ -36,7 +41,7 @@ public class Hash512 extends FixedBytes implements Comparable<Hash512> {
      * @param hex hex value, may optionally start with 0x prefix
      * @return hash instance
      * @throws IllegalArgumentException if value has invalid length
-     * @throws NumberFormatException if value has invalid format (non-hex characters, etc)
+     * @throws NumberFormatException    if value has invalid format (non-hex characters, etc)
      */
     public static Hash512 from(String hex) {
         byte[] parsed = parseHex(hex, SIZE_BYTES);
@@ -46,5 +51,39 @@ public class Hash512 extends FixedBytes implements Comparable<Hash512> {
     @Override
     public int compareTo(Hash512 o) {
         return super.compareTo(o);
+    }
+
+    /**
+     * Custom serialization logic. Writes the length and value of the underlying byte array for the hash.
+     *
+     * @param out the {@link ObjectOutputStream} to write this object to
+     * @throws IOException if an I/O error occurs while writing to the stream
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
+    /**
+     * Custom deserialization logic. Validates the required length and sets the underlying byte array using reflection.
+     *
+     * @param in the {@link ObjectInputStream} to read this object from
+     * @throws IOException            if the length of the serialized data is invalid or if an I/O error occurs
+     * @throws ClassNotFoundException if the class of a serialized object cannot be found
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        int length = in.readInt();
+        if (length != SIZE_BYTES) {
+            throw new IOException("Invalid Hash512 length: " + length);
+        }
+        byte[] value = new byte[length];
+        in.readFully(value);
+        try {
+            java.lang.reflect.Field valueField = ByteData.class.getDeclaredField("value");
+            valueField.setAccessible(true);
+            valueField.set(this, value.clone());
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new IOException("Failed to initialize Hash512", e);
+        }
     }
 }

--- a/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/FixedBytesSpec.groovy
+++ b/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/FixedBytesSpec.groovy
@@ -17,6 +17,4 @@ class FixedBytesSpec extends Specification {
         def t = thrown(IllegalStateException)
         t.message.contains("Different size")
     }
-
-
 }

--- a/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/Hash256Spec.groovy
+++ b/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/Hash256Spec.groovy
@@ -189,4 +189,24 @@ class Hash256Spec extends Specification {
         then:
         hash1.hashCode() != hash2.hashCode()
     }
+
+    def "Deserialization produces expected Hash256"() {
+        setup:
+        def hash = Hash256.from("0x63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b")
+        def serialized = SerializationUtil.serialize(hash)
+        when:
+        def deserialized = SerializationUtil.deserialize(serialized)
+        then:
+        deserialized instanceof Hash256
+        deserialized.toString() == "0x63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b"
+    }
+
+    def "Cannot deserialize invalid length bytes"() {
+        setup:
+        def serialized = new byte[]{1, 2, 3, 4}
+        when:
+        SerializationUtil.deserialize(serialized)
+        then:
+        thrown(IllegalArgumentException)
+    }
 }

--- a/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/Hash512Spec.groovy
+++ b/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/Hash512Spec.groovy
@@ -189,4 +189,18 @@ class Hash512Spec extends Specification {
         then:
         hash1.hashCode() != hash2.hashCode()
     }
+
+    def "Deserialization produces expected Hash512"() {
+        setup:
+        def hash = Hash512.from(
+                "0x63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b" +
+                        "63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b")
+        def serialized = SerializationUtil.serialize(hash)
+        when:
+        def deserialized = SerializationUtil.deserialize(serialized)
+        then:
+        deserialized instanceof Hash512
+        deserialized.toString() == "0x63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b" +
+                "63c2499de640b43c924bc2bfc9ea89730e7c4790e24d126906e7af6c99cb506b"
+    }
 }

--- a/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/SerializationUtil.java
+++ b/polkaj-common-types/src/test/groovy/io/emeraldpay/polkaj/types/SerializationUtil.java
@@ -1,0 +1,37 @@
+package io.emeraldpay.polkaj.types;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class SerializationUtil {
+
+    public static byte[] serialize(Object object) {
+        if (object == null) {
+            return null;
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(object);
+            oos.flush();
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Failed to serialize object of type: " + object.getClass(), ex);
+        }
+        return baos.toByteArray();
+    }
+
+    public static Object deserialize(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return ois.readObject();
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Failed to deserialize object", ex);
+        } catch (ClassNotFoundException ex) {
+            throw new IllegalStateException("Failed to deserialize object type", ex);
+        }
+    }
+}


### PR DESCRIPTION
The `Hash512` and `Hash256` classes don't work with java's default serialization logic. Considering they are nothing but wrapper around a byte array field it is adequate to only serialize/deserialize the byte array value of each instance. This PR implements the custom logic needed for that.